### PR TITLE
Use the from html field as reply-to email field

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ They are JSON files placed in the `/targets` directory.
 **Example target:**
 ```json
 {
-    "smtp": "smtps://username:password@smtp.example.com",
+    "smtp": "smtps://sender:password@smtp.example.com",
     "origin": "my-website.com",
-    "recipients": ["example@example.com"],
+    "from": "sender@example.com",
+    "recipients": ["recipient@example.com"],
     "rateLimit": {
         "timespan": 300,
         "requests": 1
@@ -82,7 +83,7 @@ They are JSON files placed in the `/targets` directory.
 - `smtp` *required* | A valid SMTP(S) url.
 - `origin` *optional* | A HTTP origin that is used for CORS and to restrict access. Default is * if not set.
 - `recipients` *required* | An array of email addresses which should receive the email.
-- `from` *optional* | The "from" field of an email. This is used as fallback if no "from" is provided in the request.
+- `from` *required* | The "from" field of an email.
 - `key` *optional* | A string used as API key if you want to restrict access to this target.
 - `redirect` *optional*:
   - `success` *optional*: A valid URL to redirect the user if the mail was sent successful.
@@ -100,7 +101,8 @@ For the exact validations of the fields please see here: [target.ts](/src/models
 ### Fields
 Whether as formular data or json, the fields are the same.
 
-- `from` *optional* | The email address of the sender. If this filed is not set, the "from" field of your target will be used.
+- `from` *optional* | The email address of the sender. This field is used as reply-to field of the email.
+  This field is NOT used as from field of the email to prevent email spoofing. See SPF (Sender Policy Framework) for further information.
 - `firstName` *optional* | A classic first name filed which will be attached to the "from" field of the email.
 - `lastName` *optional* | A classic last name filed which will be attached to the "from" field of the email.
 - `subject` *required* | The email subject.
@@ -152,7 +154,7 @@ Content-Type: application/json
 Authorization: Bearer your-optional-api-key
 
 {
-  "from": "example@example.com",
+  "from": "user@example.com",
   "subject": "your subect",
   "body": "your message",
 }

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ Authorization: Bearer your-optional-api-key
 
 **Possible status codes:**
 - `200` Email was successfully sent.
+- `400` Parsing the request body failed.
 - `401` Authentication failed: API key not present or wrong.
 - `403` Forbidden because of wrong origin header.
 - `404` Target not found.
+- `422` Validation errors.
 - `500` Sending the email failed.
 
 ## 👋 Contribution

--- a/src/@types/target.ts
+++ b/src/@types/target.ts
@@ -2,7 +2,7 @@ export interface Target {
     smtp: string;
     origin: string;
     recipients: string[];
-    from?: string;
+    from: string;
     redirect?: Redirects;
     key?: string;
     rateLimit?: TargetRateLimit;

--- a/src/models/target.ts
+++ b/src/models/target.ts
@@ -17,7 +17,7 @@ export const targetModel = {
     },
     from: {
         type: "string",
-        presence: false
+        presence: true
     },
     redirect: {
         type: "object",

--- a/src/router.ts
+++ b/src/router.ts
@@ -65,7 +65,7 @@ router.post("/:target", async (req: Request, res: Response) => {
     form.parse(req, async (err, fields, files) => {
         if (err) {
             if(target.redirect?.error) return res.redirect(target.redirect.error);
-            return res.status(500).send({ message: "Parse Error" }).end();
+            return res.status(400).send({ message: "Parse Error" }).end();
         } else {
             const validationResult = validate(fields, postBody);
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -94,8 +94,8 @@ router.post("/:target", async (req: Request, res: Response) => {
             const fieldBody = fields["body"] instanceof Array ? fields["body"][0] : fields["body"]
 
             // send email
-            let from = EmailService.formatFromField(fieldFrom ?? target.from, fieldFirstName, fieldLastName);
-            let sent = await EmailService.sendMail(req.params.target, from, fieldSubject, fieldBody, files);
+            let replyTo = EmailService.formatFromField(fieldFrom, fieldFirstName, fieldLastName);
+            let sent = await EmailService.sendMail(req.params.target, target.from, replyTo, fieldSubject, fieldBody, files);
 
             if(sent instanceof Error || !sent) {
                 if(target.redirect?.error) return res.redirect(target.redirect.error);

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -78,12 +78,13 @@ export class EmailService {
      * Send an email
      * @param targetName (file-)name of an existing and loaded target
      * @param from Email from field
+     * @param replyTo Email reply-to field
      * @param subject Email subject field
      * @param body Email body
      * @param files Formidable files
      * @return Promise<boolean|Error> True if success, error object if not success
      */
-    public static async sendMail(targetName: string, from: string, subject: string, body: string, files: FormidableFiles): Promise<boolean|Error> {
+    public static async sendMail(targetName: string, from: string, replyTo: string, subject: string, body: string, files: FormidableFiles): Promise<boolean|Error> {
 
         if(!this.targetTransports.has(targetName)) return false;
 
@@ -94,7 +95,7 @@ export class EmailService {
         try {
             await transporter.sendMail({
                 from,
-                replyTo: from,
+                replyTo,
                 to: target.recipients,
                 subject,
                 html: body,


### PR DESCRIPTION
Sending emails for a domain (e.g. sender-domain.org) via a SMTP server that isn't authorized to send emails for (e.g. evil-domain.org) is email spoofing. This may cause the email to be rejected or classified as spam.

See:
- https://en.wikipedia.org/wiki/Email_spoofing
- https://en.wikipedia.org/wiki/Sender_Policy_Framework