### PR TITLE
Require target.from as fallback, add replyTo support with sensible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 📨 MailForm
+
 > The lightweight email service for contact forms and more!
 
 This is basically a minimal self-hosted open source alternative to [Formspree](https://formspree.io/) and [SendGrid](https://sendgrid.com/).
@@ -6,6 +7,7 @@ This is basically a minimal self-hosted open source alternative to [Formspree](h
 Unlike other mail services (that often gives you an API key for backends), this self-hosted mail service is designed to be accessed directly from a frontend, but also offers you the option to use it as a mail service with configurable API keys.
 
 ### Features
+
 - Access via API or HTML form with redirects
 - Configurable CORS and Origin restriction
 - ReCaptcha and hCaptcha support
@@ -13,11 +15,13 @@ Unlike other mail services (that often gives you an API key for backends), this 
 - Optional API keys
 
 ### Planned features
+
 - [ ] Email Templates
 - [x] File Uploads for attachments
 - [x] ReCaptcha and hCaptcha support
 
 ### Used frameworks & libraries
+
 - [Express](https://expressjs.com/)
 - [Typescript](https://www.typescriptlang.org/)
 - [Nodemailer](https://nodemailer.com/about/)
@@ -26,7 +30,9 @@ Unlike other mail services (that often gives you an API key for backends), this 
 - [axios](https://github.com/axios/axios)
 
 ## 💽 Installation
+
 ### Docker
+
 ```shell
 git clone https://github.com/Feuerhamster/mailform.git
 cd mailform
@@ -38,7 +44,8 @@ docker run Feuerhamster/mailform
 ```
 
 ### Manually
-*Requires NodeJS 16 or higher*
+
+_Requires NodeJS 16 or higher_
 
 ```shell
 git clone https://github.com/Feuerhamster/mailform.git
@@ -49,67 +56,88 @@ npm run start
 ```
 
 ## ⚙️Configuration
+
 ### Application
+
 MailForm can be configured using environment variables.
 
 **Environment variables:**
+
 - `PORT` The port on which the application starts. If not provided, a random port will be selected.
 - `TARGETS_DIR` Path to the directory with your target files. Default is `/targets` of the project root.
 - `PROXY` A boolean that enables the "trust proxy" option of Express. **Enable this if you're using MailForm behind a reverse proxy like NGINX!** Default value is false.
 
 ### Targets
+
 Targets are your different endpoints each with its own rate limits and smtp provider.
-They are JSON files placed in the `/targets` directory. 
+They are JSON files placed in the `/targets` directory.
 
 **Example target:**
+
 ```json
 {
-    "smtp": "smtps://username:password@smtp.example.com",
-    "origin": "my-website.com",
-    "recipients": ["example@example.com"],
-    "rateLimit": {
-        "timespan": 300,
-        "requests": 1
-    },
-    "captcha": {
-        "provider": "hcaptcha",
-        "secret": "xxx"
-    }
+  "smtp": "smtps://username:password@smtp.example.com",
+  "origin": "my-website.com",
+  "recipients": ["example@example.com"],
+  "from": "no-reply@example.com",
+  "rateLimit": {
+    "timespan": 300,
+    "requests": 1
+  },
+  "captcha": {
+    "provider": "hcaptcha",
+    "secret": "xxx"
+  }
 }
 ```
 
 **Available fields:**
-- `smtp` *required* | A valid SMTP(S) url.
-- `origin` *optional* | A HTTP origin that is used for CORS and to restrict access. Default is * if not set.
-- `recipients` *required* | An array of email addresses which should receive the email.
-- `from` *optional* | The "from" field of an email. This is used as fallback if no "from" is provided in the request.
-- `subjectPrefix` *optional* | A target-wide prefix for the email subject.
-- `key` *optional* | A string used as API key if you want to restrict access to this target.
-- `redirect` *optional*:
-  - `success` *optional*: A valid relative or absolute URL to redirect the user if the mail was sent successful.
-  - `error` *optional*: A valid relative or absolute URL to redirect the user if the mail can't be sent due to an error.
-- `rateLimit` *required*:
-    - `timespan` *required* | Timespan (in seconds) for the rate limiter to reset.
-    - `requests` *required* | Allowed amount of requests in the given timespan.
-- `captcha` *optional*:
-  - `provider` *required if captcha* | The captcha provider ("recaptcha" or "hcaptcha").
-  - `secret` *required if captcha* | Secret key for your captcha.
+
+**Required**
+
+- `smtp` | A valid SMTP(S) url.
+- `recipients` | An array of email addresses which should receive the email.
+- `from` | The default "from" address used as fallback when no `from` is provided in the request. A `from` supplied in the request overrides this value.
+- `rateLimit.timespan` | Timespan (in seconds) for the rate limiter to reset.
+- `rateLimit.requests` | Allowed amount of requests in the given timespan.
+
+**Optional**
+
+- `origin` | A HTTP origin that is used for CORS and to restrict access. Default is \* if not set.
+- `replyTo` | The "replyTo" field of an email. If not provided in the request, it defaults to the effective `from` that is used for the email.
+- `subjectPrefix` | A target-wide prefix for the email subject.
+- `key` | A string used as API key if you want to restrict access to this target.
+- `redirect.success` | A valid relative or absolute URL to redirect the user if the mail was sent successful.
+- `redirect.error` | A valid relative or absolute URL to redirect the user if the mail can't be sent due to an error.
+- `captcha` | Enables captcha verification for the target.
+  - `captcha.provider` _required if captcha_ | The captcha provider ("recaptcha" or "hcaptcha").
+  - `captcha.secret` _required if captcha_ | Secret key for your captcha.
 
 For the exact validations of the fields please see here: [target.ts](/src/models/target.ts)
 
 ## 📫 Usage
+
 ### Fields
+
 Whether as formular data or json, the fields are the same.
 
-- `from` *optional* | The email address of the sender. If this filed is not set, the "from" field of your target will be used.
-- `firstName` *optional* | A classic first name filed which will be attached to the "from" field of the email.
-- `lastName` *optional* | A classic last name filed which will be attached to the "from" field of the email.
-- `subjectPrefix` *optional* | A Prefix for the email subject.
-- `subject` *required* | The email subject.
-- `body` *required* | The email body (supports HTML).
-  
-- `g-recaptcha-response` *only required if target use captcha* | Field for ReCaptcha response.
-- `h-captcha-response` *only required if target use captcha* | Field for hCaptcha response.
+**Required**
+
+- `subject` | The email subject.
+- `body` | The email body (supports HTML).
+
+**Optional**
+
+- `from` | The email address of the sender. If this field is not set, the target's `from` will be used. If set, it overrides the target's `from`.
+- `replyTo` | Reply-to address. If not set, it defaults to the effective `from`.
+- `firstName` | A classic first name filed which will be attached to the "from" field of the email.
+- `lastName` | A classic last name filed which will be attached to the "from" field of the email.
+- `subjectPrefix` | A Prefix for the email subject.
+
+**Only required if the target uses captcha**
+
+- `g-recaptcha-response` | Field for ReCaptcha response.
+- `h-captcha-response` | Field for hCaptcha response.
 
 For the exact validations of the fields please see here: [posts.ts](/src/models/post.ts)
 
@@ -117,6 +145,7 @@ For the exact validations of the fields please see here: [posts.ts](/src/models/
 If no redirect is set, http status codes will be returned.
 
 ### Captchas
+
 MailForm supports both [ReCaptcha](https://www.google.com/recaptcha/) and [hCaptcha](https://www.hcaptcha.com/).
 
 To use captchas, you have to configure it in your target.
@@ -128,28 +157,34 @@ If you use an API request, you have to fill it manually.
 ### HTML Form
 
 **Example html form:**
+
 ```html
-<form method="post" action="https://mailform.yourserver.com/your-target-file-name">
-    <input type="email" name="from" placeholder="Sender's email address"/>
-    <input type="text" name="firstName" placeholder="First name" />
-    <input type="text" name="lastName" placeholder="Last name" />
-    <input type="hidden" name="subjectPrefix" value="[App-Question] " />
-    <input type="text" name="subject" placeholder="Subject" />
-    <div class="g-recaptcha" data-sitekey="your_site_key"></div>
-    <textarea name="body" placeholder="Your message"></textarea>
+<form
+  method="post"
+  action="https://mailform.yourserver.com/your-target-file-name"
+>
+  <input type="email" name="from" placeholder="Sender's email address" />
+  <input type="text" name="firstName" placeholder="First name" />
+  <input type="text" name="lastName" placeholder="Last name" />
+  <input type="hidden" name="subjectPrefix" value="[App-Question] " />
+  <input type="text" name="subject" placeholder="Subject" />
+  <div class="g-recaptcha" data-sitekey="your_site_key"></div>
+  <textarea name="body" placeholder="Your message"></textarea>
 </form>
 ```
 
 To work properly, you may want to configure a redirect in the target.
 
 ### API
+
 Simply make a request to `/:target` (replace with your target's file name).
 If you have set an API key, add the HTTP Authorization header with type `Bearer` and then the key.
 Make sure to also use the right origin (if not set automatically because the request is from a backend).
 
 > ⚠ Since the file upload feature got added, there is an Issue with `application/json`. Please use multipart form or form urlencoded for API requests. I am working on a rewrite where this gets fixed.
 
-**Example request:** 
+**Example request:**
+
 ```http request
 POST https://mailform.yourserver.com/your-target-file-name
 Origin: your-configured-origin.com
@@ -164,6 +199,7 @@ Authorization: Bearer your-optional-api-key
 ```
 
 **Possible status codes:**
+
 - `200` Email was successfully sent.
 - `401` Authentication failed: API key not present or wrong.
 - `403` Forbidden because of wrong origin header.
@@ -171,6 +207,7 @@ Authorization: Bearer your-optional-api-key
 - `500` Sending the email failed.
 
 ## 👋 Contribution
+
 Feel free to create issues and pull requests if you want!
 
 Please keep up with the code style and discuss new features beforehand with the project owner.

--- a/src/@types/target.ts
+++ b/src/@types/target.ts
@@ -1,31 +1,32 @@
 export interface Target {
-    smtp: string;
-    origin: string;
-    recipients: string[];
-    from?: string;
-    subjectPrefix?: string;
-    redirect?: Redirects;
-    key?: string;
-    rateLimit?: TargetRateLimit;
-    captcha?: TargetCaptchaOptions
+  smtp: string;
+  origin: string;
+  recipients: string[];
+  replyTo?: string;
+  from: string;
+  subjectPrefix?: string;
+  redirect?: Redirects;
+  key?: string;
+  rateLimit?: TargetRateLimit;
+  captcha?: TargetCaptchaOptions;
 }
 
 export interface Redirects {
-    success?: string;
-    error?: string
+  success?: string;
+  error?: string;
 }
 
 export interface TargetRateLimit {
-    timespan: number;
-    requests: number;
+  timespan: number;
+  requests: number;
 }
 
 export interface TargetCaptchaOptions {
-    provider: CaptchaProvider;
-    secret: string;
+  provider: CaptchaProvider;
+  secret: string;
 }
 
 export enum CaptchaProvider {
-    RECAPTCHA = "recaptcha",
-    HCAPTCHA = "hcaptcha"
+  RECAPTCHA = "recaptcha",
+  HCAPTCHA = "hcaptcha",
 }

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -1,55 +1,60 @@
 export const postBody = {
-    from: {
-        type: "string",
-        presence: false,
-        email: true
+  from: {
+    type: "string",
+    presence: false,
+    email: true,
+  },
+  replyTo: {
+    type: "string",
+    presence: false,
+    email: true,
+  },
+  firstName: {
+    type: "string",
+    presence: false,
+    length: {
+      minimum: 2,
+      maximum: 100,
     },
-    firstName: {
-        type: "string",
-        presence: false,
-        length: {
-            minimum: 2,
-            maximum: 100
-        }
+  },
+  lastName: {
+    type: "string",
+    presence: false,
+    length: {
+      minimum: 2,
+      maximum: 100,
     },
-    lastName: {
-        type: "string",
-        presence: false,
-        length: {
-            minimum: 2,
-            maximum: 100
-        }
+  },
+  subjectPrefix: {
+    type: "string",
+    presence: false,
+    length: {
+      minimum: 1,
+      maximum: 255,
     },
-    subjectPrefix: {
-        type: "string",
-        presence: false,
-        length: {
-            minimum: 1,
-            maximum: 255
-        }
+  },
+  subject: {
+    type: "string",
+    presence: { allowEmpty: false },
+    length: {
+      minimum: 2,
+      maximum: 255,
     },
-    subject: {
-        type: "string",
-        presence: { allowEmpty: false },
-        length: {
-            minimum: 2,
-            maximum: 255
-        }
+  },
+  body: {
+    type: "string",
+    presence: { allowEmpty: false },
+    length: {
+      minimum: 5,
+      maximum: 32000,
     },
-    body: {
-        type: "string",
-        presence: { allowEmpty: false },
-        length: {
-            minimum: 5,
-            maximum: 32000
-        }
-    },
-    "g-recaptcha-response": {
-        type: "string",
-        presence: false
-    },
-    "h-captcha-response": {
-        type: "string",
-        presence: false
-    }
-}
+  },
+  "g-recaptcha-response": {
+    type: "string",
+    presence: false,
+  },
+  "h-captcha-response": {
+    type: "string",
+    presence: false,
+  },
+};

--- a/src/models/target.ts
+++ b/src/models/target.ts
@@ -1,62 +1,66 @@
 export const targetModel = {
-    smtp: {
-        type: "string",
-        presence: { allowEmpty: false },
-        url: {
-            schemes: ["smtp", "smtps"],
-            allowLocal: true
-        }
+  smtp: {
+    type: "string",
+    presence: { allowEmpty: false },
+    url: {
+      schemes: ["smtp", "smtps"],
+      allowLocal: true,
     },
-    origin: {
-        type: "string",
-        presence: false
-    },
-    recipients: {
-        type: "array",
-        presence: { allowEmpty: false }
-    },
-    from: {
-        type: "string",
-        presence: false
-    },
-    subjectPrefix: {
-        type: "string",
-        presence: false
-    },
-    redirect: {
-        type: "object",
-        presence: false
-    },
-    "redirect.success": {
-        type: "string",
-        presence: false
-    },
-    "redirect.error": {
-        type: "string",
-        presence: false
-    },
-    key: {
-        type: "string",
-        presence: false
-    },
-    rateLimit: {
-        type: "object",
-        presence: { allowEmpty: false }
-    },
-    "rateLimit.timespan": {
-        type: "number",
-        presence: true
-    },
-    "rateLimit.requests": {
-        type: "number",
-        presence: true
-    },
-    captcha: {
-        type: "object",
-        presence: false
-    },
-    "captcha.provider": {
-        type: "string",
-        inclusion: ["recaptcha", "hcaptcha"]
-    }
-}
+  },
+  origin: {
+    type: "string",
+    presence: false,
+  },
+  recipients: {
+    type: "array",
+    presence: { allowEmpty: false },
+  },
+  from: {
+    type: "string",
+    presence: { allowEmpty: false },
+  },
+  replyTo: {
+    type: "string",
+    presence: false,
+  },
+  subjectPrefix: {
+    type: "string",
+    presence: false,
+  },
+  redirect: {
+    type: "object",
+    presence: false,
+  },
+  "redirect.success": {
+    type: "string",
+    presence: false,
+  },
+  "redirect.error": {
+    type: "string",
+    presence: false,
+  },
+  key: {
+    type: "string",
+    presence: false,
+  },
+  rateLimit: {
+    type: "object",
+    presence: { allowEmpty: false },
+  },
+  "rateLimit.timespan": {
+    type: "number",
+    presence: true,
+  },
+  "rateLimit.requests": {
+    type: "number",
+    presence: true,
+  },
+  captcha: {
+    type: "object",
+    presence: false,
+  },
+  "captcha.provider": {
+    type: "string",
+    inclusion: ["recaptcha", "hcaptcha"],
+  },
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,13 @@
-import {NextFunction, Request, Response, Router} from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import formidable from "formidable";
-import { firstValues } from 'formidable/src/helpers/firstValues.js';
-import {TargetManager} from "./services/targetManager";
-import {Target} from "./@types/target";
-import {RateLimiter} from "./services/rateLimiter";
+import { firstValues } from "formidable/src/helpers/firstValues.js";
+import { TargetManager } from "./services/targetManager";
+import { Target } from "./@types/target";
+import { RateLimiter } from "./services/rateLimiter";
 import validate from "./services/validate";
-import {postBody} from "./models/post";
-import {EmailService} from "./services/email";
-import {CaptchaService} from "./services/captcha";
+import { postBody } from "./models/post";
+import { EmailService } from "./services/email";
+import { CaptchaService } from "./services/captcha";
 import getRedirectUrl from "./util/redirect";
 
 const router: Router = Router();
@@ -15,106 +15,161 @@ const router: Router = Router();
 /**
  * Check if target exist, validate origin and send CORS headers.
  */
-router.use("/:target", async (req: Request, res: Response, next: NextFunction) => {
-
+router.use(
+  "/:target",
+  async (req: Request, res: Response, next: NextFunction) => {
     // Check if target exist
-    if(!TargetManager.targets.has(req.params.target)) {
-        return res.sendStatus(404);
+    if (!TargetManager.targets.has(req.params.target)) {
+      return res.sendStatus(404);
     }
 
     let target: Target = TargetManager.targets.get(req.params.target);
 
     // CORS
-    res.setHeader("Access-Control-Allow-Origin", target.origin ? target.origin : "*");
+    res.setHeader(
+      "Access-Control-Allow-Origin",
+      target.origin ? target.origin : "*"
+    );
     res.setHeader("Access-Control-Allow-Method", "POST");
     res.setHeader("Access-Control-Allow-Headers", "*");
 
-    if(req.method === "OPTIONS") {
-        return res.status(200).end();
+    if (req.method === "OPTIONS") {
+      return res.status(200).end();
     }
 
     // Check origin
-    if(target.origin && target.origin !== req.header("origin")) {
-        if(target.redirect?.error) return res.redirect(getRedirectUrl(req, target.redirect.error));
-        return res.status(403).end();
+    if (target.origin && target.origin !== req.header("origin")) {
+      if (target.redirect?.error)
+        return res.redirect(getRedirectUrl(req, target.redirect.error));
+      return res.status(403).end();
     }
 
     // Authentication
-    if(target.key) {
-        let bearer = /Bearer (.+)/.exec(req.headers.authorization);
+    if (target.key) {
+      let bearer = /Bearer (.+)/.exec(req.headers.authorization);
 
-        if(!bearer || bearer[1] !== target.key) {
-            if(target.redirect?.error) return res.redirect(getRedirectUrl(req, target.redirect.error));
-            return res.status(401).end();
-        }
+      if (!bearer || bearer[1] !== target.key) {
+        if (target.redirect?.error)
+          return res.redirect(getRedirectUrl(req, target.redirect.error));
+        return res.status(401).end();
+      }
     }
 
     return next();
-
-});
+  }
+);
 
 router.post("/:target", async (req: Request, res: Response) => {
+  // Check rate limit
+  if (!(await RateLimiter.consume(req.params.target, req.ip))) {
+    return res.status(429).end();
+  }
 
-    // Check rate limit
-    if(!await RateLimiter.consume(req.params.target, req.ip)) {
-        return res.status(429).end();
-    }
+  let target: Target = TargetManager.targets.get(req.params.target);
 
-    let target: Target = TargetManager.targets.get(req.params.target);
+  // parse form
+  const form = formidable({});
+  form.parse(req, async (err, fieldsMultiple, files) => {
+    if (err) {
+      if (target.redirect?.error)
+        return res.redirect(getRedirectUrl(req, target.redirect.error));
+      return res.status(500).send({ message: "Parse Error" }).end();
+    } else {
+      const fields = firstValues(form, fieldsMultiple, []);
+      const validationResult = validate(fields, postBody);
 
-    // parse form
-    const form = formidable({});
-    form.parse(req, async (err, fieldsMultiple, files) => {
-        if (err) {
-            if(target.redirect?.error) return res.redirect(getRedirectUrl(req, target.redirect.error));
-            return res.status(500).send({ message: "Parse Error" }).end();
-        } else {
-            const fields = firstValues(form, fieldsMultiple, []);
-            const validationResult = validate(fields, postBody);
+      // validate fields
+      if (validationResult.error) {
+        return res.status(422).json(validationResult);
+      }
 
-            // validate fields
-            if(validationResult.error) {
-                return res.status(422).json(validationResult);
-            }
+      // Check captcha
+      if (target.captcha) {
+        let userCaptchaResponse =
+          fields["g-recaptcha-response"] ||
+          fields["h-captcha-response"] ||
+          null;
+        userCaptchaResponse =
+          userCaptchaResponse instanceof Array
+            ? userCaptchaResponse[0]
+            : userCaptchaResponse;
+        let verified = await CaptchaService.verifyCaptcha(
+          target.captcha,
+          userCaptchaResponse
+        );
 
-            // Check captcha
-            if(target.captcha) {
-                let userCaptchaResponse = fields["g-recaptcha-response"] || fields["h-captcha-response"] || null;
-                userCaptchaResponse = userCaptchaResponse instanceof Array ? userCaptchaResponse[0] : userCaptchaResponse
-                let verified = await CaptchaService.verifyCaptcha(target.captcha, userCaptchaResponse);
-
-                if(!verified) {
-                    if(target.redirect?.error) return res.redirect(getRedirectUrl(req, target.redirect.error));
-                    return res.status(400).send({ message: "captcha verification failed" }).end();
-                }
-            }
-
-            // extract fields
-            const fieldFrom = fields["from"] instanceof Array ? fields["from"][0] : fields["from"]
-            const fieldFirstName = fields["firstName"] instanceof Array ? fields["firstName"][0] : fields["firstName"]
-            const fieldLastName = fields["lastName"] instanceof Array ? fields["lastName"][0] : fields["lastName"]
-            const fieldSubjectPrefix = fields["subjectPrefix"] instanceof Array ? fields["subjectPrefix"][0] : fields["subjectPrefix"] ?? ""
-            const subject = (target.subjectPrefix ?? "") + fieldSubjectPrefix + (fields["subject"] instanceof Array ? fields["subject"][0] : fields["subject"])
-            const fieldBody = fields["body"] instanceof Array ? fields["body"][0] : fields["body"]
-
-            // send email
-            let from = EmailService.formatFromField(fieldFrom ?? target.from, fieldFirstName, fieldLastName);
-            let sent = await EmailService.sendMail(req.params.target, from, subject, fieldBody, files);
-
-            if(sent instanceof Error || !sent) {
-                if(target.redirect?.error) return res.redirect(getRedirectUrl(req, target.redirect.error));
-                return res.status(500).send({ message: (<Error>sent).message }).end();
-            }
-
-            if(target.redirect?.success) {
-                return res.redirect(getRedirectUrl(req, target.redirect.success));
-            }
-
-            return res.status(200).end();
+        if (!verified) {
+          if (target.redirect?.error)
+            return res.redirect(getRedirectUrl(req, target.redirect.error));
+          return res
+            .status(400)
+            .send({ message: "captcha verification failed" })
+            .end();
         }
-    });
+      }
+
+      // extract fields
+      const fieldFrom =
+        fields["from"] instanceof Array ? fields["from"][0] : fields["from"];
+      const fieldReplyTo =
+        fields["replyTo"] instanceof Array
+          ? fields["replyTo"][0]
+          : fields["replyTo"];
+      const fieldFirstName =
+        fields["firstName"] instanceof Array
+          ? fields["firstName"][0]
+          : fields["firstName"];
+      const fieldLastName =
+        fields["lastName"] instanceof Array
+          ? fields["lastName"][0]
+          : fields["lastName"];
+      const fieldSubjectPrefix =
+        fields["subjectPrefix"] instanceof Array
+          ? fields["subjectPrefix"][0]
+          : fields["subjectPrefix"] ?? "";
+      const subject =
+        (target.subjectPrefix ?? "") +
+        fieldSubjectPrefix +
+        (fields["subject"] instanceof Array
+          ? fields["subject"][0]
+          : fields["subject"]);
+      const fieldBody =
+        fields["body"] instanceof Array ? fields["body"][0] : fields["body"];
+
+      // send email
+      let from = EmailService.formatFromField(
+        fieldFrom ?? target.from,
+        fieldFirstName,
+        fieldLastName
+      );
+      let replyTo = fieldReplyTo ?? from;
+      let sent = await EmailService.sendMail(
+        req.params.target,
+        from,
+        replyTo,
+        subject,
+        fieldBody,
+        files
+      );
+
+      if (sent instanceof Error || !sent) {
+        if (target.redirect?.error)
+          return res.redirect(getRedirectUrl(req, target.redirect.error));
+        return res
+          .status(500)
+          .send({ message: (<Error>sent).message })
+          .end();
+      }
+
+      if (target.redirect?.success) {
+        return res.redirect(getRedirectUrl(req, target.redirect.success));
+      }
+
+      return res.status(200).end();
+    }
+  });
 });
 
-router.all('/{*splat}', (req: Request, res: Response) => res.status(404).end());
+router.all("/{*splat}", (req: Request, res: Response) => res.status(404).end());
 
 export default router;

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -1,118 +1,134 @@
-import {File as FormidableFile, Files as FormidableFiles} from "formidable";
-import nodemailer, {Transporter} from "nodemailer";
-import {Attachment as NodemailerAttachment} from "nodemailer/lib/mailer";
-import {TargetManager} from "./targetManager";
-import {Target} from "../@types/target";
+import { File as FormidableFile, Files as FormidableFiles } from "formidable";
+import nodemailer, { Transporter } from "nodemailer";
+import { Attachment as NodemailerAttachment } from "nodemailer/lib/mailer";
+import { TargetManager } from "./targetManager";
+import { Target } from "../@types/target";
 
 export class EmailService {
+  private static targetTransports: Map<string, Transporter> = new Map<
+    string,
+    Transporter
+  >();
 
-    private static targetTransports: Map<string, Transporter> = new Map<string, Transporter>();
+  /**
+   * Register a target in the email service
+   * @param targetName (file-)name of an existing and loaded target
+   * @param smtpURL A valid SMTP(S) URL
+   */
+  public static registerTarget(targetName: string, smtpURL: string): void {
+    this.targetTransports.set(targetName, nodemailer.createTransport(smtpURL));
+  }
 
-    /**
-     * Register a target in the email service
-     * @param targetName (file-)name of an existing and loaded target
-     * @param smtpURL A valid SMTP(S) URL
-     */
-    public static registerTarget(targetName: string, smtpURL: string): void {
-        this.targetTransports.set(targetName, nodemailer.createTransport(smtpURL));
+  /**
+   * Map file objects from formidable to attachment objects for nodemailer
+   * @param files Formidable files
+   * @return NodemailerAttachment[]
+   */
+  private static mapFormidableFilesToNodemailerAttachments(
+    files: FormidableFiles
+  ): NodemailerAttachment[] {
+    const attachments: NodemailerAttachment[] = [];
+
+    for (const fileKey in files) {
+      const fileValue = files[fileKey];
+      const fileValues: FormidableFile[] =
+        fileValue instanceof Array ? fileValue : [fileValue];
+
+      for (const singleFileValue of fileValues) {
+        attachments.push(
+          this.mapFormidableFileToNodemailerAttachment(singleFileValue)
+        );
+      }
+    }
+    return attachments;
+  }
+
+  /**
+   * Map file object from formidable to attachment object for nodemailer
+   * @param file Formidable file
+   * @return NodemailerAttachment
+   */
+  private static mapFormidableFileToNodemailerAttachment(
+    file: FormidableFile
+  ): NodemailerAttachment {
+    return {
+      path: file.filepath,
+      filename: file.originalFilename,
+      contentType: file.mimetype,
+    };
+  }
+
+  /**
+   * Format an email "from" field with an address, first name and last name
+   * @param from
+   * @param firstName
+   * @param lastName
+   * @return string The formatted "from" field
+   */
+  public static formatFromField(
+    from: string,
+    firstName: string = null,
+    lastName: string = null
+  ): string {
+    let result = "";
+
+    if (firstName) result += firstName;
+
+    if (firstName && lastName) result += " ";
+
+    if (lastName) result += lastName;
+
+    if (result.length > 0) result += ` <${from}>`;
+
+    if (result.length < 1) result = from;
+
+    return result;
+  }
+
+  /**
+   * Send an email
+   * @param targetName (file-)name of an existing and loaded target
+   * @param replyTo Email reply-to field
+   * @param from Email from field
+   * @param subject Email subject field
+   * @param body Email body
+   * @param files Formidable files
+   * @return Promise<boolean|Error> True if success, error object if not success
+   */
+  public static async sendMail(
+    targetName: string,
+    from: string,
+    replyTo: string,
+    subject: string,
+    body: string,
+    files: FormidableFiles
+  ): Promise<boolean | Error> {
+    if (!this.targetTransports.has(targetName)) return false;
+
+    let target: Target = TargetManager.targets.get(targetName);
+
+    let transporter: Transporter = this.targetTransports.get(targetName);
+
+    try {
+      await transporter.sendMail({
+        from,
+        replyTo: replyTo,
+        to: target.recipients,
+        subject,
+        html: body,
+        attachments: this.mapFormidableFilesToNodemailerAttachments(files),
+      });
+    } catch (e) {
+      console.error("[!] An error occurred while sending an email");
+      console.error("* target: " + targetName);
+      console.error("* " + e.message);
+      return e;
     }
 
-    /**
-     * Map file objects from formidable to attachment objects for nodemailer
-     * @param files Formidable files
-     * @return NodemailerAttachment[]
-     */
-    private static mapFormidableFilesToNodemailerAttachments(files: FormidableFiles): NodemailerAttachment[] {
-        const attachments: NodemailerAttachment[] = [];
+    console.log(`Email successful sent`);
+    console.log("* target: " + targetName);
+    console.log("* time: " + new Date().toString());
 
-        for (const fileKey in files) {
-            const fileValue = files[fileKey];
-            const fileValues: FormidableFile[] = fileValue instanceof Array ? fileValue : [fileValue]
-
-            for (const singleFileValue of fileValues) {
-                attachments.push(this.mapFormidableFileToNodemailerAttachment(singleFileValue));
-            }
-        }
-        return attachments;
-    }
-
-    /**
-     * Map file object from formidable to attachment object for nodemailer
-     * @param file Formidable file
-     * @return NodemailerAttachment
-     */
-    private static mapFormidableFileToNodemailerAttachment(file: FormidableFile): NodemailerAttachment {
-        return {
-            path: file.filepath,
-            filename: file.originalFilename,
-            contentType: file.mimetype,
-        };
-    }
-
-    /**
-     * Format an email "from" field with an address, first name and last name
-     * @param from
-     * @param firstName
-     * @param lastName
-     * @return string The formatted "from" field
-     */
-    public static formatFromField(from: string, firstName: string = null, lastName: string = null): string {
-
-        let result = "";
-
-        if(firstName) result += firstName;
-
-        if(firstName && lastName) result += " ";
-
-        if(lastName) result += lastName;
-
-        if(result.length > 0) result += ` <${from}>`;
-
-        if(result.length < 1) result = from;
-
-        return result;
-
-    }
-
-    /**
-     * Send an email
-     * @param targetName (file-)name of an existing and loaded target
-     * @param from Email from field
-     * @param subject Email subject field
-     * @param body Email body
-     * @param files Formidable files
-     * @return Promise<boolean|Error> True if success, error object if not success
-     */
-    public static async sendMail(targetName: string, from: string, subject: string, body: string, files: FormidableFiles): Promise<boolean|Error> {
-
-        if(!this.targetTransports.has(targetName)) return false;
-
-        let target: Target = TargetManager.targets.get(targetName);
-
-        let transporter: Transporter = this.targetTransports.get(targetName);
-
-        try {
-            await transporter.sendMail({
-                from,
-                replyTo: from,
-                to: target.recipients,
-                subject,
-                html: body,
-                attachments: this.mapFormidableFilesToNodemailerAttachments(files),
-            });
-        } catch (e) {
-            console.error("[!] An error occurred while sending an email");
-            console.error("* target: " + targetName);
-            console.error("* " + e.message);
-            return e;
-        }
-
-        console.log(`Email successful sent`);
-        console.log("* target: " + targetName);
-        console.log("* time: " + new Date().toString());
-
-        return true;
-
-    }
-
+    return true;
+  }
 }


### PR DESCRIPTION
- Added support for replyTo on incoming requests.
- Made target.from required and used it as a fallback when no from is provided in the request.
- If replyTo is not provided, it defaults to the effective from (field from if present, otherwise target.from).
- Request field from continues to override target.from.
- Updated README to document required/optional fields and new defaults.

### Why

- We needed replyTo and noticed there was an open issue requesting the same feature.
- Making target.from required ensures a reliable fallback and avoids sending emails without a valid sender.

### Behavior

- from: request field overrides; otherwise fallback to target.from (required).
- replyTo: optional; defaults to the effective from when not supplied.


### Docs

- README updated: targets and request fields grouped into Required vs Optional; replyTo behavior documented.

### Migration
- Existing targets must now include from (required). Add a default like no-reply@example.com if missing.

### Closes
Closes #9 